### PR TITLE
feat(STONEINTG-485): adding daily trigger and new workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      # Prefix all commit messages with "chore(Dockerfile): "
+      prefix: "chore(Dockerfile): "
+    # Add reviewers
+    reviewers:
+      - "dirgim"
+      - "hongweiliu17"
+      - "jsztuka"
+      - "jinqi7"
+      - "Josh-Everett"
+      - "sonam1412"
+      - "MartinBasti"
+      - "dheerajodha"
+      - "14rcole"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(actions): "
+    reviewers:
+      - "dirgim"
+      - "hongweiliu17"
+      - "jsztuka"
+      - "jinqi7"
+      - "Josh-Everett"
+      - "sonam1412"
+      - "MartinBasti"
+      - "dheerajodha"
+      - "14rcole"

--- a/.github/workflows/clair-in-ci.db.yaml
+++ b/.github/workflows/clair-in-ci.db.yaml
@@ -1,0 +1,74 @@
+name: Clair in CI DB - test
+
+# This workflow tests latest database version of clair-in-ci and
+# pushes it to app-studio registry in case all tests passed
+
+on:
+  repository_dispatch:
+    types: trigger_workflow
+
+env:
+  REGISTRY: quay.io/redhat-appstudio
+  IMAGE_NAME: clair-test-build
+  LATEST_TAG: latest
+  PREVIOUS_TAG: previous
+  TO_TEST: ${{ github.event.client_payload.image_tag }} # required, fail if not specified
+  EVENT: ${{ github.event.client_payload.event }} # required, fail if not specified
+
+jobs:
+  test-and-push:
+    name: Test and push image
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check required parameters
+        run: |
+          if [ -z "${{ env.TO_TEST }}" ] || [ -z "${{ env.EVENT }}" ]; then
+            echo "Recieved: image-tag: ${{ env.TO_TEST }}, event: ${{ env.EVENT }}. Did not recieve required parameters, cancelling the workflow."
+            exit 1
+          fi
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v2.2.0
+        if: ${{ github.event.client_payload.event != 'pull_request' }}  # don't login from PR; secrets are not passed to PRs from fork
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.HACBS_TEST_QUAY_USER }}
+          password: ${{ secrets.HACBS_TEST_QUAY_TOKEN }}
+
+      - name: Setup docker for workflow
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
+      - name: Pull-and-retag-image
+        if: ${{ github.event.client_payload.event != 'pull_request' }}  # don't retag image from PR
+        run: |
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
+          docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PREVIOUS_TAG }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.PREVIOUS_TAG }}
+          docker rmi -f $(docker images -q)
+
+      - name: Get Clair version
+        run: |
+          docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TO_TEST }}
+          docker run --rm -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TO_TEST }} clair-action --version
+
+      - name: Check Clair output format
+        run: |
+          # test real life usage of clair
+          mkdir results
+          docker run --rm -v $(pwd)/results:/results:rw -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TO_TEST }} bash -c 'clair-action report --image-ref=registry.access.redhat.com/ubi9-minimal --db-path=/tmp/matcher.db --format=quay > /results/clairdata.json'
+
+
+          # check if required metadata and path to values are the same as expected
+          jq -e '.data[].Features[0] | select(has("Name") and has("Vulnerabilities")) or error("Required keys do not exist")' results/clairdata.json
+
+      - name: Retag-and-push-to-${{ env.REGISTRY }}
+        if: ${{ github.event.client_payload.event != 'pull_request' }}  # don't push image from PR
+        id: push-image
+        run: |
+          docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TO_TEST }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+    branches: [ main, daily ]
+
+jobs:
+  lint:
+    name: Lint change content
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Dockerfile linter
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          ignore: DL3041

--- a/.github/workflows/trigger-clair-db-build.yaml
+++ b/.github/workflows/trigger-clair-db-build.yaml
@@ -1,0 +1,53 @@
+name: Trigger clair db image build
+
+# This workflow creates/reopens PR and closes it
+# in order to trigger PAC to build clair DB image
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+
+env:
+  REGISTRY: quay.io/redhat-appstudio
+  IMAGE_NAME: clair-in-ci
+  LATEST_TAG: latest
+  PREVIOUS_TAG: previous
+  GITHUB_TOKEN: ${{ secrets.HACBS_TEST_GITHUB_TOKEN }}
+  TARGET_BRANCH: daily
+  SOURCE_BRANCH: main # building from main
+  IS_CREATED: false
+  PR_STATE: ""
+  PR_NUMBER: 0
+  
+
+jobs:
+  test:
+    name: Build the new image
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v3
+    - name: create pull request
+      run: |
+          echo "Check if PR is already created."
+          PR_NUMBER=$(gh pr list --state all --label clair-db --json number | jq -r '.[0] | .number')
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == null ]; then
+            echo "No existing PR with label clair-db was found. Creating a new PR..."
+            gh pr create -B $TARGET_BRANCH -H $SOURCE_BRANCH --title 'Using branch: $SOURCE_BRANCH to create PR triggering clair-db build PAC.' --body 'Created by Github action' --label clair-db
+            sleep 5
+            PR_NUMBER=$(gh pr list --state all --label clair-db --json number | jq -r '.[0] | .number')
+          fi
+          PR_STATE=$(gh pr view $PR_NUMBER --json state | jq -r '.state')
+          if [ "$PR_STATE" == "OPEN" ]; then
+            echo "$PR_NUMBER is $PR_STATE, closing it now."
+            gh pr close $PR_NUMBER
+            echo "PR number: $PR_NUMBER has been closed."
+          else
+            echo "$PR_NUMBER is $PR_STATE, reopening it now."
+            gh pr reopen $PR_NUMBER
+            echo "PR number: $PR_NUMBER has been opened."
+            sleep 5
+            gh pr close $PR_NUMBER
+            echo "PR number: $PR_NUMBER has been closed."
+          fi

--- a/.tekton/build_and_trigger.yaml
+++ b/.tekton/build_and_trigger.yaml
@@ -1,0 +1,109 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: build-and-trigger
+  annotations:
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+            event == "push" || event == "pull_request"
+    pipelinesascode.tekton.dev/task: "[buildah, git-clone]"
+spec:
+  params:
+    - name: output-image
+      value: quay.io/redhat-appstudio/clair-in-ci:to_test
+    - name: builder-image
+      value: registry.access.redhat.com/ubi9/buildah:9.0.0-19@sha256:c8b1d312815452964885680fc5bc8d99b3bfe9b6961228c71a09c72ca8e915eb
+    - name: dockerfile
+      value: Dockerfile
+    - name: revision
+      value: "{{ revision }}"
+    - name: target_branch
+      value: "{{ target_branch }}"
+    - name: source_branch
+      value: "{{ source_branch }}"
+    - name: repo_url
+      value: "{{ repo_url }}"
+  pipelineSpec:
+    params:
+      - name: output-image
+      - name: builder-image
+      - name: dockerfile
+      - name: revision
+      - name: target_branch
+      - name: source_branch
+      - name: repo_url
+    workspaces:
+      - name: workspace
+    tasks:
+      - name: fetch-repo
+        workspaces:
+          - name: output
+            workspace: workspace
+        taskRef:
+          name: git-clone
+        params:
+          - name: url
+            value: "$(params.repo_url)"
+          - name: revision
+            value: "$(params.revision)"
+      - name: build-image
+        workspaces:
+          - name: source
+            workspace: workspace
+        params:
+          - name: IMAGE
+            value: quay.io/redhat-appstudio/clair-in-ci:{{revision}}
+          - name: BUILDER_IMAGE
+            value: $(params.builder-image)
+          - name: DOCKERFILE
+            value: $(workspaces.source.path)/$(params.dockerfile)
+        runAfter:
+          - fetch-repo
+        taskRef:
+          name: buildah
+          kind: ClusterTask
+      - name: trigger-tests-and-push
+        params:
+          - name: revision
+            value: "{{ revision }}"
+          - name: target_branch
+            value: "{{ target_branch }}"
+          - name: source_branch
+            value: "{{ source_branch }}"
+        runAfter:
+          - build-image
+        taskSpec:
+          params:
+            - name: revision
+              type: string
+            - name: target_branch
+              type: string
+            - name: source_branch
+              type: string
+          steps:
+            - name: tigger-workflow
+              image: registry.access.redhat.com/ubi9/python-39
+              env:
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: integration-github-token
+                      key: integration-github-token
+              script: |
+                #!/usr/bin/env bash
+                event="pull_request"
+                if [ "$(params.target_branch)" == "daily" ]; then
+                  event="daily"
+                elif [ "$(params.target_branch)" == "main" ] && [ "$(params.source_branch)" == "main" ]; then
+                  event="push"
+                fi
+                curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" --request POST --data '{"event_type":"trigger_workflow", "client_payload": {"event": "${event}", "image_tag": "$(params.revision)"}}' https://api.github.com/repos/redhat-appstudio/clair-in-ci-db/dispatches
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/projectquay/clair-action:v0.0.5
+
+# Update the matcher database. Use the info log level to track sources
+RUN DB_PATH=/tmp/matcher.db /bin/clair-action --level info update


### PR DESCRIPTION
Use cases:

1. Create new PR that has set **main** as target branch
Building db image is skipped, **customer_payload** with such information is sent to workflow that only triggers tests (dockerfile linter)
2. Create new PR that has set **daily** as target branch (special case)
Builds image(revision) > testing the image in workflow > push this tested image as latest in registry
3. Push changes into **main** > same as #2