### PR TITLE
Removing PR creation mechanism

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    branches: [ main, daily ]
+    branches: [ main ]
 
 jobs:
   lint:

--- a/.github/workflows/trigger-clair-db-build.yaml
+++ b/.github/workflows/trigger-clair-db-build.yaml
@@ -8,12 +8,7 @@ on:
     - cron: '0 4 * * *'
 
 env:
-  REGISTRY: quay.io/redhat-appstudio
-  IMAGE_NAME: clair-in-ci
-  LATEST_TAG: latest
-  PREVIOUS_TAG: previous
   GITHUB_TOKEN: ${{ secrets.HACBS_TEST_GITHUB_TOKEN }}
-  TARGET_BRANCH: daily
   SOURCE_BRANCH: main # building from main
 
 jobs:
@@ -26,24 +21,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: 'main'
-    - name: create pull request & empty commit
+    - name: create empty commit
       run: |
           git config --global user.email "<>"
           git config --global user.name "hacbs-test-bot"
-          echo "Check if PR is already created."
-          PR_NUMBER=$(gh pr list --state all --label clair-db --json number | jq -r '.[0] | .number')
-          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == null ]; then
-            echo "No existing PR with label clair-db was found. Creating a new PR..."
-            gh pr create -B $TARGET_BRANCH -H $SOURCE_BRANCH --title 'Using branch: "${SOURCE_BRANCH}" to create PR triggering clair-db build PAC.' --body 'Created by Github action' --label clair-db
-            sleep 5
-            PR_NUMBER=$(gh pr list --state all --label clair-db --json number | jq -r '.[0] | .number')
-          fi
-          PR_STATE=$(gh pr view $PR_NUMBER --json state | jq -r '.state')
-          if [ "$PR_STATE" != "OPEN" ]; then
-            echo "$PR_NUMBER is $PR_STATE, reopening it now."
-            gh pr reopen $PR_NUMBER
-            echo "PR number: $PR_NUMBER has been opened."
-          else
+          echo "Creating empty commit."
             git commit --allow-empty -m "$(date)"
             git push origin "${SOURCE_BRANCH}" -f
-          fi

--- a/.tekton/build_and_trigger.yaml
+++ b/.tekton/build_and_trigger.yaml
@@ -17,10 +17,6 @@ spec:
       value: Dockerfile
     - name: revision
       value: "{{ revision }}"
-    - name: target_branch
-      value: "{{ target_branch }}"
-    - name: source_branch
-      value: "{{ source_branch }}"
     - name: repo_url
       value: "{{ repo_url }}"
     - name: event_type
@@ -31,8 +27,6 @@ spec:
       - name: builder-image
       - name: dockerfile
       - name: revision
-      - name: target_branch
-      - name: source_branch
       - name: repo_url
       - name: event_type
     workspaces:
@@ -53,8 +47,6 @@ spec:
         params:
           - name: revision
             value: "{{ revision }}"
-          - name: target_branch
-            value: "{{ target_branch }}"
           - name: event_type
             value: "{{ event_type }}"
         runAfter:
@@ -62,8 +54,6 @@ spec:
         taskSpec:
           params:
             - name: revision
-              type: string
-            - name: target_branch
               type: string
             - name: event_type
               type: string
@@ -77,7 +67,7 @@ spec:
                 #!/usr/bin/env bash
                 VERSION_MAJOR=v1
                 # make sure you use `echo -n` otherwise random failures are waiting for you
-                if [ "$(params.target_branch)" == "daily" ] || [ "$(params.event_type)" == "push" ]; then
+                if [ "$(params.event_type)" == "push" ]; then
                   echo -n "${VERSION_MAJOR}.$(date --utc '+%Y%m%d%H%M%S')" | tee $(results.image_tag.path)
                 else
                   echo -n "PR-$(params.revision)" | tee $(results.image_tag.path)
@@ -102,10 +92,6 @@ spec:
         params:
           - name: revision
             value: "{{ revision }}"
-          - name: target_branch
-            value: "{{ target_branch }}"
-          - name: source_branch
-            value: "{{ source_branch }}"
           - name: event_type
             value: "{{ event_type }}"
           - name: image_tag
@@ -115,10 +101,6 @@ spec:
         taskSpec:
           params:
             - name: revision
-              type: string
-            - name: target_branch
-              type: string
-            - name: source_branch
               type: string
             - name: event_type
               type: string
@@ -136,8 +118,8 @@ spec:
               script: |
                 #!/usr/bin/env bash
                 event="pull_request"
-                if [ "$(params.target_branch)" == "daily" ] || [ "$(params.event_type)" == "push" ]; then
-                  event="daily-or-push"
+                if [ "$(params.event_type)" == "push" ]; then
+                  event="push"
                 fi
                 echo "Acting according to event: "$event""
                 curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" --request POST --data '{"event_type":"trigger_workflow", "client_payload": {"pr_event": "'"$event"'", "image_tag": "$(params.image_tag)"}}' https://api.github.com/repos/redhat-appstudio/clair-in-ci-db/dispatches


### PR DESCRIPTION
Triggering tekton CI can be achieved by simply creating an empty commit each day on scheduled basis.
That is the reason why we don't need complicated PR creation(opening/closing) mechanism.
Its also triggering image builds duplicitly.