### PR TITLE
fix(tekton-PLR): add repo prefix to name

### DIFF
--- a/.tekton/build_and_trigger.yaml
+++ b/.tekton/build_and_trigger.yaml
@@ -8,6 +8,8 @@ metadata:
             event == "push" || event == "pull_request"
     pipelinesascode.tekton.dev/task: "[buildah, git-clone]"
 spec:
+  timeouts:
+    pipeline: "2h"
   params:
     - name: output-image
       value: quay.io/redhat-appstudio/clair-in-ci:to_test
@@ -76,6 +78,7 @@ spec:
                   echo -n "PR-$(params.revision)" | tee $(results.image_tag.path)
                 fi
       - name: build-image
+        timeout: "0"
         workspaces:
           - name: source
             workspace: workspace

--- a/.tekton/build_and_trigger.yaml
+++ b/.tekton/build_and_trigger.yaml
@@ -36,6 +36,9 @@ spec:
         workspaces:
           - name: output
             workspace: workspace
+        computeResources:
+          requests:
+            cpu: 100mi
         taskRef:
           name: git-clone
         params:
@@ -76,6 +79,9 @@ spec:
         workspaces:
           - name: source
             workspace: workspace
+        computeResources:
+          requests:
+            cpu: 1
         params:
           - name: IMAGE
             value: "quay.io/redhat-appstudio/clair-in-ci:$(tasks.calculate-tag.results.image_tag)"
@@ -89,6 +95,9 @@ spec:
           name: buildah
           kind: ClusterTask
       - name: trigger-tests-and-push
+        computeResources:
+          requests:
+            cpu: 100mi
         params:
           - name: revision
             value: "{{ revision }}"

--- a/.tekton/build_and_trigger.yaml
+++ b/.tekton/build_and_trigger.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  name: build-and-trigger
+  name: clair-in-ci-db-build-and-trigger
   annotations:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |


### PR DESCRIPTION
This allows us to easily identify in tekton namespace which PLRs belongs to clair-in-ci-db