### PR TITLE
fix(STONEINTG-694): tekton-ci - clair-in-ci-db token

### DIFF
--- a/.tekton/build_and_trigger.yaml
+++ b/.tekton/build_and_trigger.yaml
@@ -125,8 +125,8 @@ spec:
                 - name: GITHUB_TOKEN
                   valueFrom:
                     secretKeyRef:
-                      name: integration-github-token
-                      key: integration-github-token
+                      name: clair-in-ci-db-github-token
+                      key: github-token
               script: |
                 #!/usr/bin/env bash
                 event="pull_request"


### PR DESCRIPTION
Migrating clair-in-ci-db github token into separate key withint integration-service away from build-service namespace.