### PR TITLE
fix(clair-db): reduce clair db size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/clair-action:v0.0.7
+FROM quay.io/projectquay/clair-action:v0.0.8
 
 # Update the matcher database. Use the info log level to track sources
 RUN DB_PATH=/tmp/matcher.db /bin/clair-action --level info update


### PR DESCRIPTION
Newest clair-action release has reduced DB size from 20 GB to 7.2 GB.