### PR TITLE
feat(STONEINTG-1644): add skills to repo

### DIFF
--- a/.claude/skills/ci-pipeline-debugging
+++ b/.claude/skills/ci-pipeline-debugging
@@ -1,0 +1,1 @@
+../../skills/ci-pipeline-debugging

--- a/.claude/skills/daily-db-update
+++ b/.claude/skills/daily-db-update
@@ -1,0 +1,1 @@
+../../skills/daily-db-update

--- a/.claude/skills/hermetic-build-deps
+++ b/.claude/skills/hermetic-build-deps
@@ -1,0 +1,1 @@
+../../skills/hermetic-build-deps

--- a/.claude/skills/pr-definition-of-done
+++ b/.claude/skills/pr-definition-of-done
@@ -1,0 +1,1 @@
+../../skills/pr-definition-of-done

--- a/skills/SKILLS.md
+++ b/skills/SKILLS.md
@@ -1,0 +1,32 @@
+# Clair-in-CI-DB AI Skills
+
+Repository-specific AI skills for the clair-in-ci-db vulnerability scanner image. These skills are tool-agnostic and can be used with any AI agent (Claude Code, Codex, Goose, etc.) via symlinks to the agent's skill directory.
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| [ci-pipeline-debugging](ci-pipeline-debugging/SKILL.md) | Tekton build pipeline structure, task ordering, resource requirements, security scans, and common failures |
+| [hermetic-build-deps](hermetic-build-deps/SKILL.md) | How RPM and artifact dependency files work together with Cachi2 for hermetic builds |
+| [pr-definition-of-done](pr-definition-of-done/SKILL.md) | Pre-push checklist: commits, Dockerfile linting, formatting rules, CI checks |
+| [daily-db-update](daily-db-update/SKILL.md) | Automated daily vulnerability database update flow and troubleshooting |
+
+## Setup for Claude Code
+
+Skills are symlinked from `.claude/skills/` for automatic discovery:
+
+```
+.claude/skills/ci-pipeline-debugging -> ../../skills/ci-pipeline-debugging
+.claude/skills/hermetic-build-deps -> ../../skills/hermetic-build-deps
+.claude/skills/pr-definition-of-done -> ../../skills/pr-definition-of-done
+.claude/skills/daily-db-update -> ../../skills/daily-db-update
+```
+
+## Setup for Other Agents
+
+Create symlinks from your agent's skill directory to `skills/`:
+
+```bash
+# Example for Codex
+ln -s ../../skills/ci-pipeline-debugging .agents/skills/ci-pipeline-debugging
+```

--- a/skills/SKILLS.md
+++ b/skills/SKILLS.md
@@ -28,5 +28,6 @@ Create symlinks from your agent's skill directory to `skills/`:
 
 ```bash
 # Example for Codex
-ln -s ../../skills/ci-pipeline-debugging .agents/skills/ci-pipeline-debugging
+mkdir -p .agents/skills
+ln -s ../../skills/ci-pipeline-debugging .agents/skills/
 ```

--- a/skills/ci-pipeline-debugging/SKILL.md
+++ b/skills/ci-pipeline-debugging/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: ci-pipeline-debugging
+description: Use when a Tekton build pipeline fails, when you need to understand task ordering or resource requirements, or when debugging security scan failures. Covers PR and push pipeline differences, the fetch-db-data step, and all security scan tasks.
+---
+
+# CI Pipeline Debugging
+
+## Overview
+
+This repo has two Tekton PipelineRun definitions in `.tekton/`: one for pull requests and one for pushes to main. Both are hermetic builds using trusted artifacts (OCI TA) with Cachi2 prefetching. The most critical and failure-prone step is `fetch-db-data`, which downloads the Clair vulnerability database and needs 16-32 GiB of memory.
+
+## When to Use
+
+- A Tekton pipeline task failed and you need to understand what it does
+- You need to understand the task execution order
+- The `fetch-db-data` step is failing (OOM, timeout, network)
+- A security scan is blocking the pipeline
+- You need to understand PR vs push pipeline differences
+
+## Task Execution Order
+
+```
+init
+  └─ clone-repository
+       └─ fetch-db-data (non-hermetic, downloads matcher.db)
+            └─ prefetch-dependencies (RPMs + generic artifacts via Cachi2)
+                 └─ build-container (buildah, hermetic)
+                      └─ build-image-index
+                           ├─ clair-scan
+                           ├─ clamav-scan
+                           ├─ sast-snyk-check
+                           ├─ sast-shell-check
+                           ├─ sast-unicode-check
+                           ├─ coverity-availability-check → sast-coverity-check
+                           ├─ ecosystem-cert-preflight-checks
+                           ├─ deprecated-base-image-check
+                           ├─ rpms-signature-scan
+                           ├─ apply-tags
+                           ├─ push-dockerfile
+                           └─ build-source-image (push only)
+finally:
+  └─ show-sbom
+```
+
+## PR vs Push Pipeline Differences
+
+| Aspect | PR Pipeline | Push Pipeline |
+|--------|------------|---------------|
+| File | `.tekton/clair-in-ci-db-hermetic-pull-request.yaml` | `.tekton/clair-in-ci-db-hermetic-push.yaml` |
+| Trigger | `event == "pull_request" && target_branch == "main"` | `event == "push" && target_branch == "main"` |
+| Image tag | `on-pr-{{revision}}` | `{{revision}}` |
+| Image expiry | 5 days | None (permanent) |
+| Cancel in-progress | Yes | No |
+| Max kept runs | 3 | 3 |
+| Source image build | No | Yes (when enabled) |
+| Pipeline timeout | 2 hours | 2 hours |
+
+## fetch-db-data Step (Most Common Failure Point)
+
+This step downloads the latest Clair vulnerability database. It is the most resource-intensive and failure-prone task.
+
+| Property | Value |
+|----------|-------|
+| Task | `run-script-oci-ta` |
+| Runner image | `quay.io/projectquay/clair-action:v0.0.12` |
+| Command | `DB_PATH=matcher.db /bin/clair-action --level info update` |
+| Hermetic | **No** (needs network access to download DB) |
+| CPU request/limit | 2 / 4 cores |
+| Memory request/limit | 16 GiB / 32 GiB |
+| Timeout | 2 hours |
+
+The output artifact (`SCRIPT_ARTIFACT`) is passed to `prefetch-dependencies`, which means the `matcher.db` file is included in the source artifact chain and eventually available during the `build-container` step where the Dockerfile `COPY matcher.db /tmp/matcher.db` picks it up.
+
+## Resource Requirements
+
+Most tasks request 10 GiB memory. Key allocations:
+
+| Task | Memory (request/limit) | Notes |
+|------|----------------------|-------|
+| fetch-db-data | 16 GiB / 32 GiB | Database download + processing |
+| build-container | 10 GiB / 10 GiB | buildah image build |
+| prefetch-dependencies | 10 GiB / 10 GiB | Cachi2 RPM + generic artifact download |
+| clair-scan | 10 GiB / 10 GiB | Vulnerability scanning of built image |
+| clamav-scan | 10 GiB / 10 GiB | Antivirus scan |
+
+## Security Scan Tasks
+
+All scans run in parallel after `build-image-index` and can be skipped with `skip-checks: "true"`:
+
+| Scan | Task Bundle | What It Checks |
+|------|------------|----------------|
+| Clair | `task-clair-scan:0.3` | CVE vulnerabilities in container image |
+| ClamAV | `task-clamav-scan:0.3` | Malware/virus scan |
+| Snyk SAST | `task-sast-snyk-check-oci-ta:0.4` | Static analysis security testing |
+| ShellCheck | `task-sast-shell-check-oci-ta:0.1` | Shell script security and quality |
+| Unicode | `task-sast-unicode-check-oci-ta:0.4` | Homoglyph/trojan-source attacks |
+| Coverity | `task-sast-coverity-check-oci-ta:0.3` | Deep static analysis (if available) |
+| RPM signatures | `task-rpms-signature-scan:0.2` | Verifies RPM package signatures |
+| Preflight | `task-ecosystem-cert-preflight-checks:0.2` | Red Hat certification checks |
+| Deprecated image | `task-deprecated-image-check:0.5` | Base image deprecation warnings |
+
+## Common Failures
+
+| Problem | Likely Cause | Fix |
+|---------|-------------|-----|
+| fetch-db-data OOM killed | Database processing exceeds memory | Check if clair-action version needs more memory; may need to increase limits |
+| fetch-db-data timeout | Network slow or database very large | Retry; check clair-action upstream for issues |
+| prefetch-dependencies fails | Lock files out of sync with rpms.in.yaml | Regenerate `rpms.lock.yaml` and `artifacts.lock.yaml` |
+| build-container fails | Dockerfile error or missing prefetched deps | Check Dockerfile syntax; verify all deps are in lock files |
+| clair-scan fails | High/critical CVEs found in built image | Review CVE report; update base image or add exceptions |
+| rpms-signature-scan fails | Unsigned or incorrectly signed RPM | Verify RPM source and GPG key in artifacts.lock.yaml |
+| Pipeline stuck at coverity | Coverity not available in tenant | Expected — coverity-availability-check gates it |
+
+## Trusted Artifacts (OCI TA)
+
+This pipeline uses OCI-based trusted artifacts instead of PVCs for sharing data between tasks:
+- Source code is stored as OCI artifacts in the output image registry
+- `SOURCE_ARTIFACT` results chain through: clone → fetch-db-data → prefetch → build
+- `CACHI2_ARTIFACT` carries prefetched dependencies from prefetch → build
+- Artifacts expire based on `ociArtifactExpiresAfter` (PR: 5 days, push: never)

--- a/skills/daily-db-update/SKILL.md
+++ b/skills/daily-db-update/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: daily-db-update
+description: Use when troubleshooting the automated daily vulnerability database update, understanding the build trigger flow, or debugging fetch-db-data failures. Covers the GitHub Actions cron, push pipeline, matcher.db lifecycle, and manual triggering.
+---
+
+# Daily Database Update
+
+## Overview
+
+The entire purpose of this repo is to keep the Clair vulnerability database fresh. A GitHub Actions cron job runs daily at ~04:00 UTC, pushes an empty commit to `main`, which triggers the Tekton push pipeline. The pipeline's `fetch-db-data` step downloads the latest vulnerability database (`matcher.db`) from upstream Clair sources, and the Dockerfile bakes it into the container image.
+
+## When to Use
+
+- The daily build didn't run or failed
+- `fetch-db-data` is failing (OOM, timeout, network)
+- You need to manually trigger a database update
+- You need to understand why the image has stale vulnerability data
+- The integration test fails after a DB update
+
+## Daily Update Flow
+
+```
+GitHub Actions cron (04:00 UTC daily)
+  │
+  ├─ .github/workflows/trigger-clair-db-build.yaml
+  │    └─ Checks out main
+  │    └─ Creates empty commit: git commit --allow-empty -m "$(date)"
+  │    └─ Force pushes to main
+  │
+  ▼
+PAC detects push to main
+  │
+  ├─ Triggers .tekton/clair-in-ci-db-hermetic-push.yaml
+  │
+  ▼
+Tekton Push Pipeline
+  │
+  ├─ clone-repository
+  ├─ fetch-db-data (NON-HERMETIC)
+  │    └─ DB_PATH=matcher.db /bin/clair-action --level info update
+  │    └─ Downloads latest vulnerability data from upstream sources
+  │    └─ Produces matcher.db as part of SOURCE_ARTIFACT
+  ├─ prefetch-dependencies (hermetic RPM + generic artifacts)
+  ├─ build-container (hermetic)
+  │    └─ Dockerfile: COPY matcher.db /tmp/matcher.db
+  │    └─ ENV DB_PATH=/tmp/matcher.db
+  ├─ security scans (clair, clamav, snyk, etc.)
+  └─ integration test (clair_validation.yaml)
+       └─ Scans ubi9-minimal with the new image
+       └─ Verifies valid vulnerability data in output
+```
+
+## fetch-db-data Details
+
+This is the most critical and failure-prone step in the entire pipeline.
+
+| Property | Value |
+|----------|-------|
+| Task bundle | `run-script-oci-ta:0.1` |
+| Runner image | `quay.io/projectquay/clair-action:v0.0.12` |
+| Command | `DB_PATH=matcher.db /bin/clair-action --level info update` |
+| Hermetic | **No** — explicitly set `HERMETIC: "false"` |
+| CPU | 2 cores request, 4 cores limit |
+| Memory | 16 GiB request, 32 GiB limit |
+| Timeout | 2 hours |
+
+Why non-hermetic: The vulnerability database must be downloaded from live upstream sources (NVD, Red Hat, etc.) at build time. This is the only step in the pipeline that has network access — all other steps run hermetically.
+
+## Manual Trigger
+
+To manually trigger a database update outside the daily schedule:
+
+1. **Via GitHub UI**: Go to Actions → "Trigger clair db image build" → "Run workflow" (uses `workflow_dispatch`)
+2. **Via CLI**: `gh workflow run trigger-clair-db-build.yaml`
+
+Both trigger the same flow: empty commit to main → PAC push pipeline.
+
+## Push Pipeline Specifics
+
+| Property | Value |
+|----------|-------|
+| File | `.tekton/clair-in-ci-db-hermetic-push.yaml` |
+| Image tag | `{{revision}}` (commit SHA) |
+| Image expiry | None (permanent) |
+| Cancel in-progress | No (`"false"`) — each build runs to completion |
+| Output registry | `quay.io/redhat-user-workloads/rhtap-integration-tenant/clair-in-ci-db-hermetic` |
+| Service account | `build-pipeline-clair-in-ci-db-hermetic` |
+
+## Integration Test Validation
+
+After the push pipeline builds the image, the integration test (`integration-tests/clair_validation.yaml`) validates it:
+
+```bash
+clair-action report \
+  --image-ref=registry.access.redhat.com/ubi9-minimal \
+  --db-path=/tmp/matcher.db \
+  --format=quay > clairdata.json
+
+jq -e '.data[].Features[0] | select(has("Name") and has("Vulnerabilities")) \
+  or error("Required keys do not exist")' clairdata.json
+```
+
+This confirms the image can actually scan containers and produce valid vulnerability data with the embedded database.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Action |
+|---------|-------------|--------|
+| Daily build didn't trigger | GH Actions cron didn't fire or failed | Check Actions tab; manually trigger via workflow_dispatch |
+| fetch-db-data OOM killed | Vulnerability DB processing exceeds 32 GiB | Check clair-action upstream for memory regression; may need limit increase |
+| fetch-db-data timeout (>2h) | Slow network or very large DB update | Retry; check upstream Clair for known issues |
+| fetch-db-data network error | Upstream vulnerability sources unreachable | Transient — retry; check NVD/Red Hat feed status |
+| Integration test fails | matcher.db is corrupt or incomplete | Check fetch-db-data logs for partial download or processing errors |
+| Image has stale vuln data | Daily build failing silently | Check push pipeline run history in Konflux dashboard |
+| Empty commit push rejected | Branch protection or permission issue | Verify the GH Actions token has `contents: write` permission |
+
+## Monitoring
+
+To check if daily updates are working:
+
+1. **GitHub Actions**: Check the "Trigger clair db image build" workflow runs for daily execution
+2. **Konflux dashboard**: Check push PipelineRun history for `clair-in-ci-db-hermetic-on-push`
+3. **Quay.io**: Check `quay.io/redhat-user-workloads/rhtap-integration-tenant/clair-in-ci-db-hermetic` for recent image tags
+4. **Git log**: `git log --oneline main` — should show daily empty commits from "daily-build-trigger"

--- a/skills/hermetic-build-deps/SKILL.md
+++ b/skills/hermetic-build-deps/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: hermetic-build-deps
+description: Use when adding, updating, or troubleshooting RPM or artifact dependencies for the hermetic build. Covers rpms.in.yaml, rpms.lock.yaml, artifacts.lock.yaml, epel.repo, Cachi2 prefetching, and the Dockerfile install step.
+---
+
+# Hermetic Build Dependencies
+
+## Overview
+
+This repo uses Konflux hermetic builds — the `build-container` task runs with no network access. All external dependencies (RPMs, GPG keys) must be prefetched by Cachi2 during the `prefetch-dependencies` task and made available offline. Four files control this system and must stay in sync.
+
+## When to Use
+
+- Adding a new RPM package to the image
+- Updating a pinned RPM version
+- Prefetch-dependencies task is failing
+- Understanding how Dockerfile installs relate to lock files
+- Updating the EPEL GPG key or repository configuration
+
+## Dependency Files
+
+| File | Purpose | Format |
+|------|---------|--------|
+| `rpms.in.yaml` | Declares which packages to install | `packages: [jq]` + repo config pointer |
+| `rpms.lock.yaml` | Pinned RPM versions, repos, checksums | Auto-generated lock file |
+| `artifacts.lock.yaml` | Pinned generic artifacts (GPG keys, individual RPMs) | Manual checksums for non-repo downloads |
+| `epel.repo` | EPEL 8 yum/dnf repository configuration | Standard repo file format |
+
+## How They Work Together
+
+```
+rpms.in.yaml          ─── declares "I need jq" + points to epel.repo
+    │
+    ├─ rpms.lock.yaml  ─── resolves jq to exact version + checksum from repos
+    │
+    └─ epel.repo       ─── provides the EPEL 8 metalink URL for resolution
+
+artifacts.lock.yaml    ─── pins the EPEL GPG key + individual RPM downloads
+                           (these are fetched as "generic" artifacts by Cachi2)
+```
+
+### In the Tekton Pipeline
+
+The `prefetch-input` parameter tells Cachi2 what to prefetch:
+
+```yaml
+prefetch-input: '[{"type": "rpm", "path": "."}, {"type": "generic", "path": "."}]'
+```
+
+- `type: rpm` — reads `rpms.in.yaml` → resolves via `rpms.lock.yaml` → downloads RPMs
+- `type: generic` — reads `artifacts.lock.yaml` → downloads listed artifacts by URL + checksum
+
+### In the Dockerfile
+
+Prefetched artifacts land in `/cachi2/output/deps/`:
+
+```dockerfile
+RUN rpm --import /cachi2/output/deps/generic/RPM-GPG-KEY-EPEL-8 && \
+    microdnf -y --setopt=tsflags=nodocs install \
+    --setopt=install_weak_deps=0 \
+    jq-1.6-11.el8_10 && \
+    microdnf clean all
+```
+
+Key points:
+- GPG key is imported from the Cachi2 generic artifacts path
+- `microdnf install` uses exact version (`jq-1.6-11.el8_10`) matching `rpms.lock.yaml`
+- `--setopt=tsflags=nodocs` and `--setopt=install_weak_deps=0` minimize image size
+
+## Current Dependencies
+
+### RPMs (via rpms.in.yaml + rpms.lock.yaml)
+| Package | Pinned Version |
+|---------|---------------|
+| jq | 1.6-11.el8_10 |
+
+### Generic Artifacts (via artifacts.lock.yaml)
+| Artifact | Source |
+|----------|--------|
+| RPM-GPG-KEY-EPEL-8 | `dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8` |
+| jq-1.6-11.el8_10.x86_64.rpm | `cdn-ubi.redhat.com` (UBI 8 appstream) |
+| oniguruma-6.8.2-3.el8.x86_64.rpm | `cdn-ubi.redhat.com` (UBI 8 appstream, jq dependency) |
+
+## How to Add a New RPM
+
+1. Add the package name to `rpms.in.yaml`:
+   ```yaml
+   packages: [jq, newpackage]
+   ```
+
+2. Regenerate the lock file (requires the Cachi2 CLI or a Konflux workspace):
+   ```bash
+   cachi2 fetch-deps --source . rpm
+   ```
+
+3. If the RPM or its dependencies need to be pinned as generic artifacts, add entries to `artifacts.lock.yaml` with the download URL and SHA-256 checksum
+
+4. Update the Dockerfile to install the new package with its exact version:
+   ```dockerfile
+   microdnf -y --setopt=tsflags=nodocs install \
+   --setopt=install_weak_deps=0 \
+   jq-1.6-11.el8_10 \
+   newpackage-x.y-z.el8 && \
+   ```
+
+5. Keep it as a single `RUN` layer to minimize image size
+
+## How to Update an Existing RPM Version
+
+1. Update the version in `rpms.lock.yaml` (or regenerate with Cachi2)
+2. Update the checksum in `artifacts.lock.yaml` if the RPM is also listed there
+3. Update the exact version string in the Dockerfile `microdnf install` command
+4. All three must match
+
+## Common Mistakes
+
+| Problem | Fix |
+|---------|-----|
+| prefetch-dependencies fails with checksum mismatch | Checksums in `artifacts.lock.yaml` or `rpms.lock.yaml` are stale — regenerate or update |
+| Build fails with "package not found" | RPM version in Dockerfile doesn't match `rpms.lock.yaml` pinned version |
+| GPG key import fails | `artifacts.lock.yaml` checksum for `RPM-GPG-KEY-EPEL-8` is wrong or key URL changed |
+| New package not installed | Added to `rpms.in.yaml` but didn't regenerate `rpms.lock.yaml` |
+| Transitive dependency missing | Add the dependency RPM to `artifacts.lock.yaml` as a generic artifact (like `oniguruma` for `jq`) |
+| Hermetic build fails with network error | Verify all deps are in lock files — hermetic builds have no network access |

--- a/skills/hermetic-build-deps/SKILL.md
+++ b/skills/hermetic-build-deps/SKILL.md
@@ -88,10 +88,11 @@ Key points:
    packages: [jq, newpackage]
    ```
 
-2. Regenerate the lock file (requires the Cachi2 CLI or a Konflux workspace):
+2. Regenerate the lock file using `rpm-lockfile-prototype`:
    ```bash
-   cachi2 fetch-deps --source . rpm
+   rpm-lockfile-prototype --image <BASE_IMAGE> rpms.in.yaml
    ```
+   This resolves packages against the base image, producing `rpms.lock.yaml` with exact versions and checksums. See [Konflux docs](https://konflux.pages.redhat.com/docs/users/building/prefetching-dependencies.html#enabling-prefetch-builds-for-rpm) for details.
 
 3. If the RPM or its dependencies need to be pinned as generic artifacts, add entries to `artifacts.lock.yaml` with the download URL and SHA-256 checksum
 
@@ -100,7 +101,7 @@ Key points:
    microdnf -y --setopt=tsflags=nodocs install \
    --setopt=install_weak_deps=0 \
    jq-1.6-11.el8_10 \
-   newpackage-x.y-z.el8 && \
+   newpackage-x.y-z.el8
    ```
 
 5. Keep it as a single `RUN` layer to minimize image size

--- a/skills/pr-definition-of-done/SKILL.md
+++ b/skills/pr-definition-of-done/SKILL.md
@@ -34,7 +34,7 @@ Every PR to this repo triggers GitHub Actions workflows (hadolint, agentready) a
 ### Code Formatting
 - [ ] No whitespace changes to unrelated code
 - [ ] No whitespace or tabs on empty lines
-- [ ] No trailing newlines at end of file (last newline is at end of code)
+- [ ] Exactly one newline at the end of the file (no extra blank lines)
 - [ ] No removal of unrelated code or unnecessary file changes
 
 ### Dependency Changes
@@ -85,7 +85,7 @@ Runs automatically after the Tekton build pipeline succeeds:
 
 ## CODEOWNERS
 
-All files are owned by the integration-service team. Reviews are automatically requested from: @dirgim @hongweiliu17 @jsztuka @Josh-Everett @kasemAlem @sonam1412 @14rcole @jencull @NigelByrne1
+All files are owned by the integration-service team. Reviews are automatically requested based on the `.github/CODEOWNERS` file.
 
 ## Common Mistakes
 

--- a/skills/pr-definition-of-done/SKILL.md
+++ b/skills/pr-definition-of-done/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: pr-definition-of-done
+description: Use when preparing a pull request for review or when CI checks fail. Checklist covering commit conventions, Dockerfile linting, formatting rules, security, and all CI checks that run on PRs.
+---
+
+# PR Definition of Done
+
+## Overview
+
+Every PR to this repo triggers GitHub Actions workflows (hadolint, agentready) and a Tekton build pipeline (hermetic image build + security scans + integration test). This checklist covers what CI enforces and what reviewers expect.
+
+## When to Use
+
+- Before pushing a PR for review
+- When CI checks fail and you need to understand why
+- When reviewing someone else's PR
+
+## Pre-Push Checklist
+
+### Commits
+- [ ] Conventional format: `type(JIRA-ID): description` (e.g., `fix(STONEINTG-1644): update jq version`)
+- [ ] Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`
+- [ ] Signed off (DCO): `git commit -s`
+- [ ] Title < 72 chars, description lines < 72 chars
+- [ ] AI-assisted work: add `Assisted-by: <tool-name>` trailer
+
+### Dockerfile
+- [ ] Well-formatted, no unnecessary layers
+- [ ] Passes hadolint (DL3041 is ignored — `microdnf` usage is expected)
+- [ ] Package versions match `rpms.lock.yaml` pins exactly
+- [ ] No secrets, keys, or credentials
+- [ ] Single `RUN` for package installation to minimize layers
+
+### Code Formatting
+- [ ] No whitespace changes to unrelated code
+- [ ] No whitespace or tabs on empty lines
+- [ ] No trailing newlines at end of file (last newline is at end of code)
+- [ ] No removal of unrelated code or unnecessary file changes
+
+### Dependency Changes
+- [ ] `rpms.in.yaml`, `rpms.lock.yaml`, and `artifacts.lock.yaml` are in sync
+- [ ] Dockerfile version strings match lock file pins
+- [ ] Checksums verified for any new artifacts
+
+### Security
+- [ ] No secrets, API keys, or credentials committed
+- [ ] No sensitive information in commit messages or PR description
+
+### PR Content
+- [ ] Title: clear, descriptive, < 72 chars
+- [ ] Description explains the "why", not just the "what"
+- [ ] Testing approach described
+- [ ] Related issues or Jira tickets linked
+
+## CI Checks That Run on PRs
+
+### GitHub Actions
+
+| Workflow | File | What It Checks |
+|----------|------|----------------|
+| Dockerfile linter | `.github/workflows/linters.yaml` | hadolint on `Dockerfile` (ignores DL3041) |
+| Agentready | `.github/workflows/agentready.yaml` | AI-readiness assessment of repo structure |
+
+### Tekton Pipeline (`.tekton/clair-in-ci-db-hermetic-pull-request.yaml`)
+
+| Phase | Tasks |
+|-------|-------|
+| Build | init → clone → fetch-db-data → prefetch → build-container → build-image-index |
+| Security scans | clair-scan, clamav-scan, sast-snyk-check, sast-shell-check, sast-unicode-check, sast-coverity-check, rpms-signature-scan, ecosystem-cert-preflight-checks, deprecated-base-image-check |
+| Finalize | show-sbom, apply-tags, push-dockerfile |
+
+### Integration Test (`integration-tests/clair_validation.yaml`)
+
+Runs automatically after the Tekton build pipeline succeeds:
+1. Extracts container image from Snapshot
+2. Runs hadolint on the Dockerfile source
+3. Runs `clair-action report` against `registry.access.redhat.com/ubi9-minimal` using the built image
+4. Validates output contains valid vulnerability data (named Features with Vulnerabilities)
+
+### PR Image Behavior
+- Tag: `on-pr-{{revision}}`
+- Expires after: 5 days
+- Cancel in-progress: yes (new push cancels previous PR pipeline)
+- Max kept: 3 pipeline runs
+
+## CODEOWNERS
+
+All files are owned by the integration-service team. Reviews are automatically requested from: @dirgim @hongweiliu17 @jsztuka @Josh-Everett @kasemAlem @sonam1412 @14rcole @jencull @NigelByrne1
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| hadolint fails | Check Dockerfile syntax; DL3041 is ignored but other rules apply |
+| Pipeline timeout | fetch-db-data has 2h timeout and needs 16-32 GiB — this is expected for large DB updates |
+| Checksum mismatch in prefetch | Lock files are out of sync — regenerate `rpms.lock.yaml` and `artifacts.lock.yaml` |
+| Integration test fails | Built image can't scan ubi9-minimal — check that matcher.db was correctly built into the image |
+| Commit not signed off | Use `git commit -s` or amend with `git commit --amend -s` |


### PR DESCRIPTION
add 4 AI skills for agentic development:
 - ci-pipeline-debugging
 - hermetic-build-deps
 - pr-definition-of-done
 - daily-db-update. Stored in skills/ with symlinks to .claude/skills/

Assisted-By: Claude Code

Ticket:  [STONEINTG-1644](https://redhat.atlassian.net/browse/STONEINTG-1644)

[STONEINTG-1644]: https://redhat.atlassian.net/browse/STONEINTG-1644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ