### PR TITLE
chore: pin github actions to commit digests

### DIFF
--- a/.github/workflows/agentready.yaml
+++ b/.github/workflows/agentready.yaml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: '3.14'
-      - uses: BSFishy/pip-action@v1
+      - uses: BSFishy/pip-action@8f2d471d809dc20b6ada98c91910b6ae6243f318 # v1
         with:
           packages: |
             agentready==2.31.2

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -41,7 +41,7 @@ jobs:
     if: >-
       github.event_name != 'issue_comment'
       || github.event.comment.user.type != 'Bot'
-    uses: konflux-ci/.fullsend/.github/workflows/dispatch.yml@main
+    uses: konflux-ci/.fullsend/.github/workflows/dispatch.yml@701e62a9c6f104ed68f8d4085d9c3b8bad3a82e4 # main
     with:
       event_action: ${{ github.event.action }}
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Dockerfile linter
-        uses: hadolint/hadolint-action@v3.4.0
+        uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0
         with:
           dockerfile: Dockerfile
           ignore: DL3041

--- a/.github/workflows/trigger-clair-db-build.yaml
+++ b/.github/workflows/trigger-clair-db-build.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         ref: 'main'
     - name: create empty commit


### PR DESCRIPTION
Achieves compliance with the organization-level policy requiring actions to be pinned to full-length commit SHAs across the konflux-ci and redhat-appstudio GitHub organizations.